### PR TITLE
bug: お問い合わせフォームが表示されない (Issue #19)

### DIFF
--- a/contact/index.md
+++ b/contact/index.md
@@ -28,4 +28,9 @@ comments:
 ---
 <h3>お問い合わせフォーム</h3>
 <p>下記フォームからお問い合わせ頂くと、Code4Lib JAPAN事務局へメールが配送されます。</p>
-<p>[iframe https://spreadsheets.google.com/spreadsheet/embeddedform?formkey=dGROM3N1QldxbGpHdExuVV9fbkRHTnc6MQ 500 700]  上記フォームが表示されない場合は、<a href="https://spreadsheets.google.com/a/code4lib.jp/spreadsheet/viewform?hl=en_US&formkey=dGROM3N1QldxbGpHdExuVV9fbkRHTnc6MQ#gid=0">こちら</a>からご利用くださるか、または件名に「Code4Lib JAPAN 問い合わせ」と記入の上、<img src="{{ site.baseurl }}/assets/uploads/2010/11/info_code4lib_mail.gif" alt="メールアドレス" />へ直接メールをお送りください。 </p>
+<p>
+  <iframe src="https://spreadsheets.google.com/spreadsheet/embeddedform?formkey=dGROM3N1QldxbGpHdExuVV9fbkRHTnc6MQ" frameborder="0" style="height:700px;width:500px;">Please upgrade your browser</iframe>
+</p>
+<p>
+  上記フォームが表示されない場合は、<a href="https://spreadsheets.google.com/a/code4lib.jp/spreadsheet/viewform?hl=en_US&formkey=dGROM3N1QldxbGpHdExuVV9fbkRHTnc6MQ#gid=0">こちら</a>からご利用くださるか、または件名に「Code4Lib JAPAN 問い合わせ」と記入の上、<img src="{{ site.baseurl }}/assets/uploads/2010/11/info_code4lib_mail.gif" alt="メールアドレス" />へ直接メールをお送りください。
+</p>


### PR DESCRIPTION
iframeタグがmarkdownに変換されていたために、Googleフォームで作成したお問合せフォームが表示されていなかった。そのため、HTMLで直書きすることで解決を図った。