### PR TITLE
記事に日付を表示し、かつフォーマットを年月日にする

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,5 @@ repository: code4lib-japan/code4lib-japan.github.io
 theme: minima
 exclude: ['README.md', 'Gemfile.lock', 'Gemfile', 'Dockerfile', 'docker-compose.yml']
 permalink: /:year/:month/:slug
+minima:
+  date_format: "%Y年%m月%d日"


### PR DESCRIPTION
テーマを「Minima」に変更したことで、記事の日付が自動的に表示されるようになったが、フォーマットが英文表記であったので、設定ファイルを編集して日付表記を「YY年MM月DD日」に変更した。