### PR TITLE
トップ画面の記事一覧タイトルを変更

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 title: Code4Lib Japan
 layout: home
+list_title: 記事一覧
 ---
 
 # UNDER CONSTRUCTION


### PR DESCRIPTION
タイトルをデフォルトの「Posts」から「記事一覧」に変更した。