### PR TITLE
2021のカンファレンスの会場を未定から、オンライン会議に変更

### DIFF
--- a/conference/index.md
+++ b/conference/index.md
@@ -20,7 +20,7 @@ comments: []
 
 <ul>
 <li>日時：2021年9月11日（土）, 9月12日（日）</li>
-<li>会場：未定</li>
+<li>会場：オンライン会議</li>
 <li>Webサイト：<a href="https://wiki.code4lib.jp/wiki/C4ljp2021">https://wiki.code4lib.jp/wiki/C4ljp2021</a></li>
 </ul>
 


### PR DESCRIPTION
2021のカンファレンスの会場を未定から、オンライン会議に変更した。