### PR TITLE
https://www.code4lib.jp/about/ のリンク切れ解決

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem "github-pages", group: :jekyll_plugins
 gem "minima"
+gem "jekyll-redirect-from"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-redirect-from
   minima
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,5 @@ minima:
   date_format: "%Y年%m月%d日"
 logo: "/assets/Code4Lib_JAPAN_logo.jpg"
 logo-alt: Code4Lib JAPAN
+plugins: 
+  - jekyll-redirect-from

--- a/about-2/index.md
+++ b/about-2/index.md
@@ -3,6 +3,8 @@ layout: page
 status: publish
 published: true
 title: Code4Lib JAPANとは
+redirect_from:
+  - /about/
 slug: "421"
 wordpress_id: 421
 wordpress_url: http://www.code4lib.jp/?page_id=2


### PR DESCRIPTION
Fixes #52
- プラグイン jekyll-redirect-from の導入