### PR TITLE
「Code4Lib JAPANとは」のSlackの招待リンクを修正

### DIFF
--- a/about-2/index.md
+++ b/about-2/index.md
@@ -70,7 +70,7 @@ Code４Lib JAPAN<br />
 <h3>Code4Lib JAPAN運営サイト</h3>
 <h4><a href="http://wiki.code4lib.jp/">Code4Lib JAPAN ウィキ</a></h4>
 <p>Code4Lib JAPANのウィキです。Code4Lib JAPAN カンファレンスの情報などを提供しています。また、Code4Lib JAPANコミュニティで共有したい情報を自由に書き込める場としても提供しています。</p>
-<h4><a href="https://join.slack.com/t/c4ljp/shared_invite/enQtNDI4NDg0NzQ2ODA3LTM4ZTI5NTk1M2M3NGU2ZjkyNmNhNzg0NmJjYTg0OWE1Njg2MDI5MDcxZmIyYjE4NzdiZGRkYjdkYmNjNjZhNTg">Code4Lib JAPAN Slack</a></h4>
+<h4><a href="https://join.slack.com/t/c4ljp/shared_invite/zt-5gucr6lz-dWeD_1oVBoPOfLi1v5UFdw">Code4Lib JAPAN Slack</a></h4>
 <p>Code4Lib JAPAN のSlackです。コミュニティの情報交換の場として提供しています。ぜひ、登録して交流しましょう。</p>
 <h4><a href="https://www.facebook.com/Code4LibJAPAN/">Code4Lib JAPAN Facebookページ</a></h4>
 <p>Code4Lib JAPANのFacebookページです。主にCode4Lib JAPANカンファレンスのイベント告知などを行なっています。</p>


### PR DESCRIPTION
5月21日時点で、「Code4Lib JAPANとは」のページにある「Code4Lib JAPAN Slack」のリンク先が、「このリンクは有効期限切れです」というエラーになっていました。
Wikiのほうの招待リンクは正常に動いているので、このページのリンクもそちらにあわせて修正します。