### PR TITLE
og:imageをURLで指定するよう修正

### DIFF
--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -1,1 +1,1 @@
-<meta property="og:image" content="/assets/Code4Lib_JAPAN_logo.jpg" />
+<meta property="og:image" content="https://www.code4lib.jp/assets/Code4Lib_JAPAN_logo.jpg" />


### PR DESCRIPTION
SNSでOGPの画像が出ないなと思っていたのですが、どうもOGPの画像はきちんとURLの絶対パスで指定する必要があるようで、相対パスではだめなようです。このため、そのようにパスの指定を修正しています。  
https://imageflux.sakura.ad.jp/column/ogp-images/
```
og:urlには、シェアされるページの正確なURLを設定します。

絶対パス（https://から始まる完全なURL）で指定しなければなりません。
```