### PR TITLE
update place of 2026 confernece

### DIFF
--- a/conference/index.md
+++ b/conference/index.md
@@ -16,7 +16,7 @@ comments: []
 <p>次回は2026年9月に開催します。</p>
 
 - 日時: 2026年9月6日（日）・7日（月）
-- 会場: オンライン
+- 会場: 三重県伊勢市（会場調整中）
 - Webサイト: [https://wiki.code4lib.jp/wiki/C4ljp2026](https://wiki.code4lib.jp/wiki/C4ljp2026)
 
 <p>&nbsp;</p>


### PR DESCRIPTION
> 以下のページで2026年の会場がオンラインになっています。
>「皇學館大学（三重県伊勢市）」もしくは「三重県伊勢市」に修正をいただけましたら幸いです。
> https://www.code4lib.jp/conference/

discordでの上記コメントに対応しました。よろしくお願いいたします。